### PR TITLE
Add "pipelines/" to leading pipeline links.

### DIFF
--- a/build_bot.rb
+++ b/build_bot.rb
@@ -28,7 +28,7 @@ class Concourse
 	def initialize(pipeline)
 		@url = "https://gpdb.data.pivotal.ci"
 		@pipeline = pipeline
-		@pipeline_url = "#{@url}/teams/main/#{@pipeline}"
+		@pipeline_url = "#{@url}/teams/main/pipelines/#{@pipeline}"
 	end
 
 	def http_get(path)


### PR DESCRIPTION
* The links will be updated (4.3_STABLE example):

from: https://gpdb.data.pivotal.ci/teams/main/4.3_STABLE
  to: https://gpdb.data.pivotal.ci/teams/main/pipelines/4.3_STABLE